### PR TITLE
feat(core): add tool filtering for MCP servers

### DIFF
--- a/docs/src/content/docs/guides/mcp.mdx
+++ b/docs/src/content/docs/guides/mcp.mdx
@@ -97,6 +97,23 @@ For **Streamable HTTP** and **Stdio** servers, each time an `Agent` runs it may 
 
 Only enable this if you're confident the tool list won't change. To invalidate the cache later, call `invalidateToolsCache()` on the server instance.
 
+### Tool filtering
+
+You can restrict which tools are exposed from each server. Pass either a static filter
+using `createStaticToolFilter` or a custom function:
+
+```ts
+const server = new MCPServerStdio({
+  fullCommand: 'my-server',
+  toolFilter: createStaticToolFilter(['safe_tool'], ['danger_tool']),
+});
+
+const dynamicServer = new MCPServerStreamableHttp({
+  url: 'http://localhost:3000',
+  toolFilter: ({ runContext }, tool) => runContext.context.allowAll || tool.name !== 'admin',
+});
+```
+
 ## Further reading
 
 - [Model Context Protocol](https://modelcontextprotocol.io/) – official specification.

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -514,9 +514,11 @@ export class Agent<
    * Fetches the available tools from the MCP servers.
    * @returns the MCP powered tools
    */
-  async getMcpTools(): Promise<Tool<TContext>[]> {
+  async getMcpTools(
+    runContext: RunContext<TContext>,
+  ): Promise<Tool<TContext>[]> {
     if (this.mcpServers.length > 0) {
-      return getAllMcpTools(this.mcpServers);
+      return getAllMcpTools(this.mcpServers, false, runContext, this);
     }
 
     return [];
@@ -527,8 +529,10 @@ export class Agent<
    *
    * @returns all configured tools
    */
-  async getAllTools(): Promise<Tool<TContext>[]> {
-    return [...(await this.getMcpTools()), ...this.tools];
+  async getAllTools(
+    runContext: RunContext<TContext>,
+  ): Promise<Tool<TContext>[]> {
+    return [...(await this.getMcpTools(runContext)), ...this.tools];
   }
 
   /**

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -74,6 +74,12 @@ export {
   MCPServerStreamableHttp,
 } from './mcp';
 export {
+  ToolFilterCallable,
+  ToolFilterContext,
+  ToolFilterStatic,
+  createStaticToolFilter,
+} from './mcpUtil';
+export {
   Model,
   ModelProvider,
   ModelRequest,

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -14,6 +14,9 @@ import {
   JsonObjectSchemaStrict,
   UnknownContext,
 } from './types';
+import type { ToolFilterCallable, ToolFilterStatic } from './mcpUtil';
+import type { RunContext } from './runContext';
+import type { Agent } from './agent';
 
 export const DEFAULT_STDIO_MCP_CLIENT_LOGGER_NAME =
   'openai-agents:stdio-mcp-client';
@@ -30,7 +33,10 @@ export interface MCPServer {
   connect(): Promise<void>;
   readonly name: string;
   close(): Promise<void>;
-  listTools(): Promise<MCPTool[]>;
+  listTools(
+    runContext?: RunContext<any>,
+    agent?: Agent<any, any>,
+  ): Promise<MCPTool[]>;
   callTool(
     toolName: string,
     args: Record<string, unknown> | null,
@@ -40,18 +46,23 @@ export interface MCPServer {
 export abstract class BaseMCPServerStdio implements MCPServer {
   public cacheToolsList: boolean;
   protected _cachedTools: any[] | undefined = undefined;
+  protected toolFilter?: ToolFilterCallable | ToolFilterStatic;
 
   protected logger: Logger;
   constructor(options: MCPServerStdioOptions) {
     this.logger =
       options.logger ?? getLogger(DEFAULT_STDIO_MCP_CLIENT_LOGGER_NAME);
     this.cacheToolsList = options.cacheToolsList ?? false;
+    this.toolFilter = options.toolFilter;
   }
 
   abstract get name(): string;
   abstract connect(): Promise<void>;
   abstract close(): Promise<void>;
-  abstract listTools(): Promise<any[]>;
+  abstract listTools(
+    runContext?: RunContext<any>,
+    agent?: Agent<any, any>,
+  ): Promise<any[]>;
   abstract callTool(
     _toolName: string,
     _args: Record<string, unknown> | null,
@@ -72,6 +83,7 @@ export abstract class BaseMCPServerStdio implements MCPServer {
 export abstract class BaseMCPServerStreamableHttp implements MCPServer {
   public cacheToolsList: boolean;
   protected _cachedTools: any[] | undefined = undefined;
+  protected toolFilter?: ToolFilterCallable | ToolFilterStatic;
 
   protected logger: Logger;
   constructor(options: MCPServerStreamableHttpOptions) {
@@ -79,12 +91,16 @@ export abstract class BaseMCPServerStreamableHttp implements MCPServer {
       options.logger ??
       getLogger(DEFAULT_STREAMABLE_HTTP_MCP_CLIENT_LOGGER_NAME);
     this.cacheToolsList = options.cacheToolsList ?? false;
+    this.toolFilter = options.toolFilter;
   }
 
   abstract get name(): string;
   abstract connect(): Promise<void>;
   abstract close(): Promise<void>;
-  abstract listTools(): Promise<any[]>;
+  abstract listTools(
+    runContext?: RunContext<any>,
+    agent?: Agent<any, any>,
+  ): Promise<any[]>;
   abstract callTool(
     _toolName: string,
     _args: Record<string, unknown> | null,
@@ -138,11 +154,14 @@ export class MCPServerStdio extends BaseMCPServerStdio {
   close(): Promise<void> {
     return this.underlying.close();
   }
-  async listTools(): Promise<MCPTool[]> {
+  async listTools(
+    runContext?: RunContext<any>,
+    agent?: Agent<any, any>,
+  ): Promise<MCPTool[]> {
     if (this.cacheToolsList && this._cachedTools) {
       return this._cachedTools;
     }
-    const tools = await this.underlying.listTools();
+    const tools = await this.underlying.listTools(runContext, agent);
     if (this.cacheToolsList) {
       this._cachedTools = tools;
     }
@@ -171,11 +190,14 @@ export class MCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
   close(): Promise<void> {
     return this.underlying.close();
   }
-  async listTools(): Promise<MCPTool[]> {
+  async listTools(
+    runContext?: RunContext<any>,
+    agent?: Agent<any, any>,
+  ): Promise<MCPTool[]> {
     if (this.cacheToolsList && this._cachedTools) {
       return this._cachedTools;
     }
-    const tools = await this.underlying.listTools();
+    const tools = await this.underlying.listTools(runContext, agent);
     if (this.cacheToolsList) {
       this._cachedTools = tools;
     }
@@ -196,6 +218,8 @@ export class MCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
 export async function getAllMcpFunctionTools<TContext = UnknownContext>(
   mcpServers: MCPServer[],
   convertSchemasToStrict = false,
+  runContext?: RunContext<TContext>,
+  agent?: Agent<TContext, any>,
 ): Promise<Tool<TContext>[]> {
   const allTools: Tool<TContext>[] = [];
   const toolNames = new Set<string>();
@@ -203,6 +227,8 @@ export async function getAllMcpFunctionTools<TContext = UnknownContext>(
     const serverTools = await getFunctionToolsFromServer(
       server,
       convertSchemasToStrict,
+      runContext,
+      agent,
     );
     const serverToolNames = new Set(serverTools.map((t) => t.name));
     const intersection = [...serverToolNames].filter((n) => toolNames.has(n));
@@ -234,13 +260,15 @@ export function invalidateServerToolsCache(serverName: string) {
 async function getFunctionToolsFromServer<TContext = UnknownContext>(
   server: MCPServer,
   convertSchemasToStrict: boolean,
+  runContext?: RunContext<TContext>,
+  agent?: Agent<TContext, any>,
 ): Promise<FunctionTool<TContext, any, unknown>[]> {
   if (server.cacheToolsList && _cachedTools[server.name]) {
     return _cachedTools[server.name];
   }
   return withMCPListToolsSpan(
     async (span) => {
-      const mcpTools = await server.listTools();
+      const mcpTools = await server.listTools(runContext, agent);
       span.spanData.result = mcpTools.map((t) => t.name);
       const tools: FunctionTool<TContext, any, string>[] = mcpTools.map((t) =>
         mcpToFunctionTool(t, server, convertSchemasToStrict),
@@ -260,8 +288,15 @@ async function getFunctionToolsFromServer<TContext = UnknownContext>(
 export async function getAllMcpTools<TContext = UnknownContext>(
   mcpServers: MCPServer[],
   convertSchemasToStrict = false,
+  runContext?: RunContext<TContext>,
+  agent?: Agent<TContext, any>,
 ): Promise<Tool<TContext>[]> {
-  return getAllMcpFunctionTools(mcpServers, convertSchemasToStrict);
+  return getAllMcpFunctionTools(
+    mcpServers,
+    convertSchemasToStrict,
+    runContext,
+    agent,
+  );
 }
 
 /**
@@ -351,6 +386,7 @@ export interface BaseMCPServerStdioOptions {
   encoding?: string;
   encodingErrorHandler?: 'strict' | 'ignore' | 'replace';
   logger?: Logger;
+  toolFilter?: ToolFilterCallable | ToolFilterStatic;
 }
 export interface DefaultMCPServerStdioOptions
   extends BaseMCPServerStdioOptions {
@@ -371,6 +407,7 @@ export interface MCPServerStreamableHttpOptions {
   clientSessionTimeoutSeconds?: number;
   name?: string;
   logger?: Logger;
+  toolFilter?: ToolFilterCallable | ToolFilterStatic;
 
   // ----------------------------------------------------
   // OAuth

--- a/packages/agents-core/src/mcpUtil.ts
+++ b/packages/agents-core/src/mcpUtil.ts
@@ -1,0 +1,46 @@
+import type { Agent } from './agent';
+import type { RunContext } from './runContext';
+import type { MCPTool } from './mcp';
+import type { UnknownContext } from './types';
+
+/** Context information available to tool filter functions. */
+export interface ToolFilterContext<TContext = UnknownContext> {
+  /** The current run context. */
+  runContext: RunContext<TContext>;
+  /** The agent requesting the tools. */
+  agent: Agent<TContext, any>;
+  /** Name of the MCP server providing the tools. */
+  serverName: string;
+}
+
+/** A function that determines whether a tool should be available. */
+export type ToolFilterCallable<TContext = UnknownContext> = (
+  context: ToolFilterContext<TContext>,
+  tool: MCPTool,
+) => boolean | Promise<boolean>;
+
+/** Static tool filter configuration using allow and block lists. */
+export interface ToolFilterStatic {
+  /** Optional list of tool names to allow. */
+  allowedToolNames?: string[];
+  /** Optional list of tool names to block. */
+  blockedToolNames?: string[];
+}
+
+/** Convenience helper to create a static tool filter. */
+export function createStaticToolFilter(
+  allowedToolNames?: string[],
+  blockedToolNames?: string[],
+): ToolFilterStatic | undefined {
+  if (!allowedToolNames && !blockedToolNames) {
+    return undefined;
+  }
+  const filter: ToolFilterStatic = {};
+  if (allowedToolNames) {
+    filter.allowedToolNames = allowedToolNames;
+  }
+  if (blockedToolNames) {
+    filter.blockedToolNames = blockedToolNames;
+  }
+  return filter;
+}

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -322,7 +322,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               setCurrentSpan(state._currentAgentSpan);
             }
 
-            const tools = await state._currentAgent.getAllTools();
+            const tools = await state._currentAgent.getAllTools(state._context);
             const serializedTools = tools.map((t) => serializeTool(t));
             const serializedHandoffs = handoffs.map((h) => serializeHandoff(h));
             if (state._currentAgentSpan) {
@@ -615,7 +615,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       while (true) {
         const currentAgent = result.state._currentAgent;
         const handoffs = currentAgent.handoffs.map(getHandoff);
-        const tools = await currentAgent.getAllTools();
+        const tools = await currentAgent.getAllTools(result.state._context);
         const serializedTools = tools.map((t) => serializeTool(t));
         const serializedHandoffs = handoffs.map((h) => serializeHandoff(h));
 

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -556,6 +556,7 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
           agentMap,
           state._currentAgent,
           stateJson.lastProcessedResponse,
+          state._context,
         )
       : undefined;
 
@@ -708,8 +709,9 @@ async function deserializeProcessedResponse<TContext = UnknownContext>(
   serializedProcessedResponse: z.infer<
     typeof serializedProcessedResponseSchema
   >,
+  runContext: RunContext<TContext>,
 ): Promise<ProcessedResponse<TContext>> {
-  const allTools = await currentAgent.getAllTools();
+  const allTools = await currentAgent.getAllTools(runContext);
   const tools = new Map(
     allTools
       .filter((tool) => tool.type === 'function')

--- a/packages/agents-core/src/shims/mcp-server/browser.ts
+++ b/packages/agents-core/src/shims/mcp-server/browser.ts
@@ -6,6 +6,8 @@ import {
   MCPServerStreamableHttpOptions,
   MCPTool,
 } from '../../mcp';
+import type { RunContext } from '../../runContext';
+import type { Agent } from '../../agent';
 
 export class MCPServerStdio extends BaseMCPServerStdio {
   constructor(params: MCPServerStdioOptions) {
@@ -20,7 +22,10 @@ export class MCPServerStdio extends BaseMCPServerStdio {
   close(): Promise<void> {
     throw new Error('Method not implemented.');
   }
-  listTools(): Promise<MCPTool[]> {
+  listTools(
+    _runContext?: RunContext<any>,
+    _agent?: Agent<any, any>,
+  ): Promise<MCPTool[]> {
     throw new Error('Method not implemented.');
   }
   callTool(
@@ -44,7 +49,10 @@ export class MCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
   close(): Promise<void> {
     throw new Error('Method not implemented.');
   }
-  listTools(): Promise<MCPTool[]> {
+  listTools(
+    _runContext?: RunContext<any>,
+    _agent?: Agent<any, any>,
+  ): Promise<MCPTool[]> {
     throw new Error('Method not implemented.');
   }
   callTool(

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -12,6 +12,9 @@ import {
   invalidateServerToolsCache,
 } from '../../mcp';
 import logger from '../../logger';
+import type { ToolFilterContext } from '../../mcpUtil';
+import type { RunContext } from '../../runContext';
+import type { Agent } from '../../agent';
 
 export interface SessionMessage {
   message: any;
@@ -97,7 +100,52 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
   }
 
   // The response element type is intentionally left as `any` to avoid explosing MCP SDK type dependencies.
-  async listTools(): Promise<MCPTool[]> {
+  protected async _applyToolFilter(
+    tools: MCPTool[],
+    runContext?: RunContext<any>,
+    agent?: Agent<any, any>,
+  ): Promise<MCPTool[]> {
+    if (!this.toolFilter) {
+      return tools;
+    }
+
+    if (typeof this.toolFilter === 'function') {
+      const ctx = {
+        runContext: runContext as RunContext<any>,
+        agent: agent as Agent<any, any>,
+        serverName: this.name,
+      } as ToolFilterContext<any>;
+      const filtered: MCPTool[] = [];
+      for (const t of tools) {
+        try {
+          const res = this.toolFilter(ctx, t);
+          const include = res instanceof Promise ? await res : res;
+          if (include) filtered.push(t);
+        } catch (e) {
+          this.logger.error(
+            `Error applying tool filter to tool '${t.name}' on server '${this.name}': ${e}`,
+          );
+        }
+      }
+      return filtered;
+    }
+
+    let filtered = tools;
+    if (this.toolFilter.allowedToolNames) {
+      const allowed = new Set(this.toolFilter.allowedToolNames);
+      filtered = filtered.filter((t) => allowed.has(t.name));
+    }
+    if (this.toolFilter.blockedToolNames) {
+      const blocked = new Set(this.toolFilter.blockedToolNames);
+      filtered = filtered.filter((t) => !blocked.has(t.name));
+    }
+    return filtered;
+  }
+
+  async listTools(
+    runContext?: RunContext<any>,
+    agent?: Agent<any, any>,
+  ): Promise<MCPTool[]> {
     const { ListToolsResultSchema } = await import(
       '@modelcontextprotocol/sdk/types.js'
     ).catch(failedToImport);
@@ -106,14 +154,17 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
         'Server not initialized. Make sure you call connect() first.',
       );
     }
+    let tools: MCPTool[];
     if (this.cacheToolsList && !this._cacheDirty && this._toolsList) {
-      return this._toolsList;
+      tools = this._toolsList;
+    } else {
+      this._cacheDirty = false;
+      const response = await this.session.listTools();
+      this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`);
+      this._toolsList = ListToolsResultSchema.parse(response).tools;
+      tools = this._toolsList;
     }
-    this._cacheDirty = false;
-    const response = await this.session.listTools();
-    this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`);
-    this._toolsList = ListToolsResultSchema.parse(response).tools;
-    return this._toolsList;
+    return this._applyToolFilter(tools, runContext, agent);
   }
 
   async callTool(
@@ -214,7 +265,51 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
   }
 
   // The response element type is intentionally left as `any` to avoid explosing MCP SDK type dependencies.
-  async listTools(): Promise<MCPTool[]> {
+  protected async _applyToolFilter(
+    tools: MCPTool[],
+    runContext?: RunContext<any>,
+    agent?: Agent<any, any>,
+  ): Promise<MCPTool[]> {
+    if (!this.toolFilter) {
+      return tools;
+    }
+    if (typeof this.toolFilter === 'function') {
+      const ctx: ToolFilterContext<any> = {
+        runContext: runContext as RunContext<any>,
+        agent: agent as Agent<any, any>,
+        serverName: this.name,
+      };
+      const filtered: MCPTool[] = [];
+      for (const t of tools) {
+        try {
+          const res = this.toolFilter(ctx, t);
+          const include = res instanceof Promise ? await res : res;
+          if (include) filtered.push(t);
+        } catch (e) {
+          this.logger.error(
+            `Error applying tool filter to tool '${t.name}' on server '${this.name}': ${e}`,
+          );
+        }
+      }
+      return filtered;
+    }
+
+    let filtered = tools;
+    if (this.toolFilter.allowedToolNames) {
+      const allowed = new Set(this.toolFilter.allowedToolNames);
+      filtered = filtered.filter((t) => allowed.has(t.name));
+    }
+    if (this.toolFilter.blockedToolNames) {
+      const blocked = new Set(this.toolFilter.blockedToolNames);
+      filtered = filtered.filter((t) => !blocked.has(t.name));
+    }
+    return filtered;
+  }
+
+  async listTools(
+    runContext?: RunContext<any>,
+    agent?: Agent<any, any>,
+  ): Promise<MCPTool[]> {
     const { ListToolsResultSchema } = await import(
       '@modelcontextprotocol/sdk/types.js'
     ).catch(failedToImport);
@@ -223,14 +318,17 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
         'Server not initialized. Make sure you call connect() first.',
       );
     }
+    let tools: MCPTool[];
     if (this.cacheToolsList && !this._cacheDirty && this._toolsList) {
-      return this._toolsList;
+      tools = this._toolsList;
+    } else {
+      this._cacheDirty = false;
+      const response = await this.session.listTools();
+      this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`);
+      this._toolsList = ListToolsResultSchema.parse(response).tools;
+      tools = this._toolsList;
     }
-    this._cacheDirty = false;
-    const response = await this.session.listTools();
-    this.debugLog(() => `Listed tools: ${JSON.stringify(response)}`);
-    this._toolsList = ListToolsResultSchema.parse(response).tools;
-    return this._toolsList;
+    return this._applyToolFilter(tools, runContext, agent);
   }
 
   async callTool(

--- a/packages/agents-core/test/mcpToolFilter.test.ts
+++ b/packages/agents-core/test/mcpToolFilter.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest';
+import { withTrace } from '../src/tracing';
+import { NodeMCPServerStdio } from '../src/shims/mcp-server/node';
+import { createStaticToolFilter } from '../src/mcpUtil';
+import { Agent } from '../src/agent';
+import { RunContext } from '../src/runContext';
+
+class StubServer extends NodeMCPServerStdio {
+  public toolList: any[];
+  constructor(name: string, tools: any[], filter?: any) {
+    super({ command: 'noop', name, toolFilter: filter, cacheToolsList: true });
+    this.toolList = tools;
+    this.session = {
+      listTools: async () => ({ tools: this.toolList }),
+      callTool: async () => [],
+      close: async () => {},
+    } as any;
+    this._cacheDirty = true;
+  }
+  async connect() {}
+  async close() {}
+}
+
+describe('MCP tool filtering', () => {
+  it('static allow/block lists', async () => {
+    await withTrace('test', async () => {
+      const tools = [
+        {
+          name: 'a',
+          description: '',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+        },
+        {
+          name: 'b',
+          description: '',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+        },
+      ];
+      const server = new StubServer(
+        's',
+        tools,
+        createStaticToolFilter(['a'], ['b']),
+      );
+      const agent = new Agent({
+        name: 'agent',
+        instructions: '',
+        model: '',
+        modelSettings: {},
+        tools: [],
+        mcpServers: [],
+      });
+      const runContext = new RunContext();
+      const result = await server.listTools(runContext, agent);
+      expect(result.map((t) => t.name)).toEqual(['a']);
+    });
+  });
+
+  it('callable filter functions', async () => {
+    await withTrace('test', async () => {
+      const tools = [
+        {
+          name: 'good',
+          description: '',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+        },
+        {
+          name: 'bad',
+          description: '',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+        },
+      ];
+      const filter = (_ctx: any, tool: any) => tool.name !== 'bad';
+      const server = new StubServer('s', tools, filter);
+      const agent = new Agent({
+        name: 'agent',
+        instructions: '',
+        model: '',
+        modelSettings: {},
+        tools: [],
+        mcpServers: [],
+      });
+      const runContext = new RunContext();
+      const result = await server.listTools(runContext, agent);
+      expect(result.map((t) => t.name)).toEqual(['good']);
+    });
+  });
+
+  it('hierarchy across multiple servers', async () => {
+    await withTrace('test', async () => {
+      const toolsA = [
+        {
+          name: 'a1',
+          description: '',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+        },
+        {
+          name: 'a2',
+          description: '',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+        },
+      ];
+      const toolsB = [
+        {
+          name: 'b1',
+          description: '',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+        },
+      ];
+      const serverA = new StubServer(
+        'A',
+        toolsA,
+        createStaticToolFilter(['a1']),
+      );
+      const serverB = new StubServer('B', toolsB);
+      const agent = new Agent({
+        name: 'agent',
+        instructions: '',
+        model: '',
+        modelSettings: {},
+        tools: [],
+        mcpServers: [],
+      });
+      const runContext = new RunContext();
+      const resultA = await serverA.listTools(runContext, agent);
+      const resultB = await serverB.listTools(runContext, agent);
+      expect(resultA.map((t) => t.name)).toEqual(['a1']);
+      expect(resultB.map((t) => t.name)).toEqual(['b1']);
+    });
+  });
+
+  it('cache interaction with filtering', async () => {
+    await withTrace('test', async () => {
+      const tools = [
+        {
+          name: 'x',
+          description: '',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+        },
+      ];
+      const server = new StubServer(
+        'cache',
+        tools,
+        createStaticToolFilter(['x']),
+      );
+      const agent = new Agent({
+        name: 'agent',
+        instructions: '',
+        model: '',
+        modelSettings: {},
+        tools: [],
+        mcpServers: [],
+      });
+      const runContext = new RunContext();
+      let result = await server.listTools(runContext, agent);
+      expect(result.map((t) => t.name)).toEqual(['x']);
+      server.toolFilter = createStaticToolFilter(['y']);
+      result = await server.listTools(runContext, agent);
+      expect(result.map((t) => t.name)).toEqual([]);
+    });
+  });
+});

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -274,7 +274,7 @@ export class RealtimeSession<
       handoff.getHandoffAsFunctionTool(),
     );
     this.#currentTools = [
-      ...(await this.#currentAgent.getAllTools()).filter(
+      ...(await this.#currentAgent.getAllTools(this.#context)).filter(
         (tool) => tool.type === 'function',
       ),
       ...handoffTools,
@@ -444,7 +444,10 @@ export class RealtimeSession<
     );
 
     const functionToolMap = new Map(
-      (await this.#currentAgent.getAllTools()).map((tool) => [tool.name, tool]),
+      (await this.#currentAgent.getAllTools(this.#context)).map((tool) => [
+        tool.name,
+        tool,
+      ]),
     );
 
     const possibleHandoff = handoffMap.get(toolCall.name);


### PR DESCRIPTION
## Summary
- implement MCP tool filtering via static lists or callback functions
- pass run context and agent to MCP tool discovery
- update Node MCP servers with filtering logic
- add unit tests for tool filters
- document tool filtering in MCP guide

## Testing
- `pnpm build`
- `pnpm test`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6863005e54ac832dbd310ab0aa0c9d23