### PR TITLE
Fix RealtimeAgent tool fetching

### DIFF
--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -273,10 +273,11 @@ export class RealtimeSession<
     const handoffTools = handoffs.map((handoff) =>
       handoff.getHandoffAsFunctionTool(),
     );
+    const allTools = await (
+      this.#currentAgent as RealtimeAgent<TBaseContext>
+    ).getAllTools(this.#context);
     this.#currentTools = [
-      ...(await this.#currentAgent.getAllTools(this.#context)).filter(
-        (tool) => tool.type === 'function',
-      ),
+      ...allTools.filter((tool) => tool.type === 'function'),
       ...handoffTools,
     ];
   }
@@ -443,12 +444,10 @@ export class RealtimeSession<
         .map((handoff) => [handoff.toolName, handoff]),
     );
 
-    const functionToolMap = new Map(
-      (await this.#currentAgent.getAllTools(this.#context)).map((tool) => [
-        tool.name,
-        tool,
-      ]),
-    );
+    const allTools = await (
+      this.#currentAgent as RealtimeAgent<TBaseContext>
+    ).getAllTools(this.#context);
+    const functionToolMap = new Map(allTools.map((tool) => [tool.name, tool]));
 
     const possibleHandoff = handoffMap.get(toolCall.name);
     if (possibleHandoff) {


### PR DESCRIPTION
## Summary
- narrow `currentAgent` type before calling `getAllTools`
- apply cast in `#setCurrentAgent` and `#handleFunctionCall`

## Testing
- `pnpm -r build-check` *(fails: Property 'toolFilter' is protected in packages/agents-core)*

------
https://chatgpt.com/codex/tasks/task_e_686309e7af98832d96f3640bc7ed564c