### PR TITLE
Add MCP tool filtering example

### DIFF
--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -12,3 +12,9 @@ Run the example from the repository root:
 ```bash
 pnpm -F mcp start:stdio
 ```
+
+`tool-filter-example.ts` shows how to expose only a subset of server tools:
+
+```bash
+pnpm -F mcp start:tool-filter
+```

--- a/examples/mcp/package.json
+++ b/examples/mcp/package.json
@@ -12,6 +12,7 @@
     "start:streamable-http": "tsx streamable-http-example.ts",
     "start:hosted-mcp-on-approval": "tsx hosted-mcp-on-approval.ts",
     "start:hosted-mcp-human-in-the-loop": "tsx hosted-mcp-human-in-the-loop.ts",
-    "start:hosted-mcp-simple": "tsx hosted-mcp-simple.ts"
+    "start:hosted-mcp-simple": "tsx hosted-mcp-simple.ts",
+    "start:tool-filter": "tsx tool-filter-example.ts"
   }
 }

--- a/examples/mcp/tool-filter-example.ts
+++ b/examples/mcp/tool-filter-example.ts
@@ -1,0 +1,51 @@
+import {
+  Agent,
+  run,
+  MCPServerStdio,
+  createStaticToolFilter,
+  withTrace,
+} from '@openai/agents';
+import * as path from 'node:path';
+
+async function main() {
+  const samplesDir = path.join(__dirname, 'sample_files');
+  const mcpServer = new MCPServerStdio({
+    name: 'Filesystem Server with filter',
+    fullCommand: `npx -y @modelcontextprotocol/server-filesystem ${samplesDir}`,
+    toolFilter: createStaticToolFilter(
+      ['read_file', 'list_directory'],
+      ['write_file'],
+    ),
+  });
+
+  await mcpServer.connect();
+
+  try {
+    await withTrace('MCP Tool Filter Example', async () => {
+      const agent = new Agent({
+        name: 'MCP Assistant',
+        instructions:
+          'Use the filesystem tools to answer questions. The write_file tool is blocked via toolFilter.',
+        mcpServers: [mcpServer],
+      });
+
+      console.log('Listing sample files:');
+      let result = await run(agent, 'List the files in the current directory.');
+      console.log(result.finalOutput);
+
+      console.log('\nAttempting to write a file (should be blocked):');
+      result = await run(
+        agent,
+        'Create a file named test.txt with the text "hello"',
+      );
+      console.log(result.finalOutput);
+    });
+  } finally {
+    await mcpServer.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add an example demonstrating MCP tool filtering
- expose the example via `start:tool-filter` script
- document how to run the new example

## Testing
- `pnpm -r build-check` *(fails: protected property)*
- `pnpm prebuild`
- `pnpm build`
- `pnpm lint`
- `CI=1 pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6863101fdc2c832db8c188b1945eda39