### PR TITLE
Update createStaticToolFilter API

### DIFF
--- a/examples/mcp/tool-filter-example.ts
+++ b/examples/mcp/tool-filter-example.ts
@@ -12,10 +12,10 @@ async function main() {
   const mcpServer = new MCPServerStdio({
     name: 'Filesystem Server with filter',
     fullCommand: `npx -y @modelcontextprotocol/server-filesystem ${samplesDir}`,
-    toolFilter: createStaticToolFilter(
-      ['read_file', 'list_directory'],
-      ['write_file'],
-    ),
+    toolFilter: createStaticToolFilter({
+      allowed: ['read_file', 'list_directory'],
+      blocked: ['write_file'],
+    }),
   });
 
   await mcpServer.connect();

--- a/packages/agents-core/src/mcpUtil.ts
+++ b/packages/agents-core/src/mcpUtil.ts
@@ -28,19 +28,19 @@ export interface ToolFilterStatic {
 }
 
 /** Convenience helper to create a static tool filter. */
-export function createStaticToolFilter(
-  allowedToolNames?: string[],
-  blockedToolNames?: string[],
-): ToolFilterStatic | undefined {
-  if (!allowedToolNames && !blockedToolNames) {
+export function createStaticToolFilter(options?: {
+  allowed?: string[];
+  blocked?: string[];
+}): ToolFilterStatic | undefined {
+  if (!options?.allowed && !options?.blocked) {
     return undefined;
   }
   const filter: ToolFilterStatic = {};
-  if (allowedToolNames) {
-    filter.allowedToolNames = allowedToolNames;
+  if (options?.allowed) {
+    filter.allowedToolNames = options.allowed;
   }
-  if (blockedToolNames) {
-    filter.blockedToolNames = blockedToolNames;
+  if (options?.blocked) {
+    filter.blockedToolNames = options.blocked;
   }
   return filter;
 }

--- a/packages/agents-core/test/mcpToolFilter.test.ts
+++ b/packages/agents-core/test/mcpToolFilter.test.ts
@@ -49,7 +49,7 @@ describe('MCP tool filtering', () => {
       const server = new StubServer(
         's',
         tools,
-        createStaticToolFilter(['a'], ['b']),
+        createStaticToolFilter({ allowed: ['a'], blocked: ['b'] }),
       );
       const agent = new Agent({
         name: 'agent',
@@ -144,7 +144,7 @@ describe('MCP tool filtering', () => {
       const serverA = new StubServer(
         'A',
         toolsA,
-        createStaticToolFilter(['a1']),
+        createStaticToolFilter({ allowed: ['a1'] }),
       );
       const serverB = new StubServer('B', toolsB);
       const agent = new Agent({
@@ -180,7 +180,7 @@ describe('MCP tool filtering', () => {
       const server = new StubServer(
         'cache',
         tools,
-        createStaticToolFilter(['x']),
+        createStaticToolFilter({ allowed: ['x'] }),
       );
       const agent = new Agent({
         name: 'agent',
@@ -193,7 +193,7 @@ describe('MCP tool filtering', () => {
       const runContext = new RunContext();
       let result = await server.listTools(runContext, agent);
       expect(result.map((t) => t.name)).toEqual(['x']);
-      server.toolFilter = createStaticToolFilter(['y']);
+      (server as any).toolFilter = createStaticToolFilter({ allowed: ['y'] });
       result = await server.listTools(runContext, agent);
       expect(result.map((t) => t.name)).toEqual([]);
     });


### PR DESCRIPTION
## Summary
- change `createStaticToolFilter` to take an options object
- update MCP example to use named options
- adjust MCP tool filter tests

## Testing
- `pnpm lint`
- `pnpm -r build-check`
- `CI=1 pnpm test` *(fails: Cannot find package '@openai/agents-core/_shims')*

------
https://chatgpt.com/codex/tasks/task_e_687001d14778832da1f923ce520b0b15