### PR TITLE
Fix MCP tool filtering

### DIFF
--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -14,7 +14,11 @@ import {
   JsonObjectSchemaStrict,
   UnknownContext,
 } from './types';
-import type { ToolFilterCallable, ToolFilterStatic } from './mcpUtil';
+import type {
+  ToolFilterCallable,
+  ToolFilterStatic,
+  ToolFilterContext,
+} from './mcpUtil';
 import type { RunContext } from './runContext';
 import type { Agent } from './agent';
 
@@ -30,6 +34,7 @@ export const DEFAULT_STREAMABLE_HTTP_MCP_CLIENT_LOGGER_NAME =
  */
 export interface MCPServer {
   cacheToolsList: boolean;
+  toolFilter?: ToolFilterCallable | ToolFilterStatic;
   connect(): Promise<void>;
   readonly name: string;
   close(): Promise<void>;
@@ -46,7 +51,7 @@ export interface MCPServer {
 export abstract class BaseMCPServerStdio implements MCPServer {
   public cacheToolsList: boolean;
   protected _cachedTools: any[] | undefined = undefined;
-  protected toolFilter?: ToolFilterCallable | ToolFilterStatic;
+  public toolFilter?: ToolFilterCallable | ToolFilterStatic;
 
   protected logger: Logger;
   constructor(options: MCPServerStdioOptions) {
@@ -83,7 +88,7 @@ export abstract class BaseMCPServerStdio implements MCPServer {
 export abstract class BaseMCPServerStreamableHttp implements MCPServer {
   public cacheToolsList: boolean;
   protected _cachedTools: any[] | undefined = undefined;
-  protected toolFilter?: ToolFilterCallable | ToolFilterStatic;
+  public toolFilter?: ToolFilterCallable | ToolFilterStatic;
 
   protected logger: Logger;
   constructor(options: MCPServerStreamableHttpOptions) {
@@ -155,13 +160,13 @@ export class MCPServerStdio extends BaseMCPServerStdio {
     return this.underlying.close();
   }
   async listTools(
-    runContext?: RunContext<any>,
-    agent?: Agent<any, any>,
+    _runContext?: RunContext<any>,
+    _agent?: Agent<any, any>,
   ): Promise<MCPTool[]> {
     if (this.cacheToolsList && this._cachedTools) {
       return this._cachedTools;
     }
-    const tools = await this.underlying.listTools(runContext, agent);
+    const tools = await this.underlying.listTools();
     if (this.cacheToolsList) {
       this._cachedTools = tools;
     }
@@ -191,13 +196,13 @@ export class MCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
     return this.underlying.close();
   }
   async listTools(
-    runContext?: RunContext<any>,
-    agent?: Agent<any, any>,
+    _runContext?: RunContext<any>,
+    _agent?: Agent<any, any>,
   ): Promise<MCPTool[]> {
     if (this.cacheToolsList && this._cachedTools) {
       return this._cachedTools;
     }
-    const tools = await this.underlying.listTools(runContext, agent);
+    const tools = await this.underlying.listTools();
     if (this.cacheToolsList) {
       this._cachedTools = tools;
     }
@@ -268,7 +273,16 @@ async function getFunctionToolsFromServer<TContext = UnknownContext>(
   }
   return withMCPListToolsSpan(
     async (span) => {
-      const mcpTools = await server.listTools(runContext, agent);
+      let mcpTools = await server.listTools(runContext, agent);
+      if (server.toolFilter) {
+        mcpTools = await filterMcpTools(
+          mcpTools,
+          server.toolFilter as ToolFilterCallable<TContext> | ToolFilterStatic,
+          runContext,
+          agent,
+          server.name,
+        );
+      }
       span.spanData.result = mcpTools.map((t) => t.name);
       const tools: FunctionTool<TContext, any, string>[] = mcpTools.map((t) =>
         mcpToFunctionTool(t, server, convertSchemasToStrict),
@@ -369,6 +383,41 @@ function ensureStrictJsonSchema(
   };
   if (!out.required) out.required = [];
   return out;
+}
+
+async function filterMcpTools<TContext = UnknownContext>(
+  tools: MCPTool[],
+  filter: ToolFilterCallable<TContext> | ToolFilterStatic,
+  runContext: RunContext<TContext> | undefined,
+  agent: Agent<TContext, any> | undefined,
+  serverName: string,
+): Promise<MCPTool[]> {
+  if (typeof filter === 'function') {
+    if (!runContext || !agent) {
+      return tools;
+    }
+    const ctx = {
+      runContext,
+      agent,
+      serverName,
+    } as ToolFilterContext<TContext>;
+    const result: MCPTool[] = [];
+    for (const tool of tools) {
+      if (await filter(ctx, tool)) {
+        result.push(tool);
+      }
+    }
+    return result;
+  }
+  return tools.filter((t) => {
+    if (filter.allowedToolNames && !filter.allowedToolNames.includes(t.name)) {
+      return false;
+    }
+    if (filter.blockedToolNames && filter.blockedToolNames.includes(t.name)) {
+      return false;
+    }
+    return true;
+  });
 }
 
 /**

--- a/packages/agents-core/test/mcpToolFilter.test.ts
+++ b/packages/agents-core/test/mcpToolFilter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { withTrace } from '../src/tracing';
 import { NodeMCPServerStdio } from '../src/shims/mcp-server/node';
 import { createStaticToolFilter } from '../src/mcpUtil';
+import { getAllMcpTools } from '../src/mcp';
 import { Agent } from '../src/agent';
 import { RunContext } from '../src/runContext';
 
@@ -196,6 +197,49 @@ describe('MCP tool filtering', () => {
       (server as any).toolFilter = createStaticToolFilter({ allowed: ['y'] });
       result = await server.listTools(runContext, agent);
       expect(result.map((t) => t.name)).toEqual(['x']);
+    });
+  });
+
+  it('applies filter in getAllMcpTools', async () => {
+    await withTrace('test', async () => {
+      const tools = [
+        {
+          name: 'allow',
+          description: '',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+        },
+        {
+          name: 'block',
+          description: '',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+        },
+      ];
+      const server = new StubServer(
+        'filter',
+        tools,
+        createStaticToolFilter({ allowed: ['allow'] }),
+      );
+      const agent = new Agent({
+        name: 'agent',
+        instructions: '',
+        model: '',
+        modelSettings: {},
+        tools: [],
+        mcpServers: [server],
+      });
+      const runContext = new RunContext();
+      const result = await getAllMcpTools([server], false, runContext, agent);
+      expect(result.map((t) => t.name)).toEqual(['allow']);
     });
   });
 });


### PR DESCRIPTION
## Summary
- expose `toolFilter` on `MCPServer` and run filtering in `getFunctionToolsFromServer`
- stop passing unused params to underlying MCP servers
- add test for filtering when retrieving tools via `getAllMcpTools`

## Testing
- `pnpm -r build-check`
- `CI=1 pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68707ac2c1b4832d9fe626eca5cba437