### PR TITLE
Fix agent update event for handoffs

### DIFF
--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -824,7 +824,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             resetCurrentSpan();
           }
           result.state._currentAgentSpan = undefined;
-          result._addItem(new RunAgentUpdatedStreamEvent(currentAgent));
+          result._addItem(
+            new RunAgentUpdatedStreamEvent(result.state._currentAgent),
+          );
           result.state._noActiveAgentRun = true;
 
           // we've processed the handoff, so we need to run the loop again

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -4,8 +4,17 @@ import {
   run,
   setDefaultModelProvider,
   setTracingDisabled,
+  Usage,
+  RunStreamEvent,
+  RunAgentUpdatedStreamEvent,
+  handoff,
+  Model,
+  ModelRequest,
+  ModelResponse,
+  StreamEvent,
+  FunctionCallItem,
 } from '../src';
-import { FakeModel, FakeModelProvider } from './stubs';
+import { FakeModel, FakeModelProvider, fakeModelMessage } from './stubs';
 
 // Test for unhandled rejection when stream loop throws
 
@@ -42,5 +51,68 @@ describe('Runner.run (streaming)', () => {
     await expect(result.completed).rejects.toThrow('Not implemented');
 
     expect((result.error as Error).message).toBe('Not implemented');
+  });
+
+  it('emits agent_updated_stream_event with new agent on handoff', async () => {
+    class SimpleStreamingModel implements Model {
+      constructor(private resp: ModelResponse) {}
+      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
+        return this.resp;
+      }
+      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'r',
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: this.resp.output,
+          },
+        } as any;
+      }
+    }
+
+    const agentB = new Agent({
+      name: 'B',
+      model: new SimpleStreamingModel({
+        output: [fakeModelMessage('done B')],
+        usage: new Usage(),
+      }),
+    });
+
+    const callItem: FunctionCallItem = {
+      id: 'h1',
+      type: 'function_call',
+      name: handoff(agentB).toolName,
+      callId: 'c1',
+      status: 'completed',
+      arguments: '{}',
+    };
+
+    const agentA = new Agent({
+      name: 'A',
+      model: new SimpleStreamingModel({
+        output: [callItem],
+        usage: new Usage(),
+      }),
+      handoffs: [handoff(agentB)],
+    });
+
+    const result = await run(agentA, 'hi', { stream: true });
+    const events: RunStreamEvent[] = [];
+    for await (const e of result.toStream()) {
+      events.push(e);
+    }
+    await result.completed;
+
+    const update = events.find(
+      (e): e is RunAgentUpdatedStreamEvent =>
+        e.type === 'agent_updated_stream_event',
+    );
+    expect(update?.agent).toBe(agentB);
   });
 });


### PR DESCRIPTION
## Summary
- fix `RunAgentUpdatedStreamEvent` to emit new agent after handoff
- test that streaming handoff emits update event with the correct agent

## Testing
- `pnpm build`
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6872d9841240832d84fe7688d775a35b