### PR TITLE
Rename tool filter utilities with MCP prefix

### DIFF
--- a/docs/src/content/docs/guides/mcp.mdx
+++ b/docs/src/content/docs/guides/mcp.mdx
@@ -100,17 +100,21 @@ Only enable this if you're confident the tool list won't change. To invalidate t
 ### Tool filtering
 
 You can restrict which tools are exposed from each server. Pass either a static filter
-using `createStaticToolFilter` or a custom function:
+using `createMCPToolStaticFilter` or a custom function:
 
 ```ts
 const server = new MCPServerStdio({
   fullCommand: 'my-server',
-  toolFilter: createStaticToolFilter({ allowed: ['safe_tool'], blocked: ['danger_tool'] }),
+  toolFilter: createMCPToolStaticFilter({
+    allowed: ['safe_tool'],
+    blocked: ['danger_tool'],
+  }),
 });
 
 const dynamicServer = new MCPServerStreamableHttp({
   url: 'http://localhost:3000',
-  toolFilter: ({ runContext }, tool) => runContext.context.allowAll || tool.name !== 'admin',
+  toolFilter: ({ runContext }, tool) =>
+    runContext.context.allowAll || tool.name !== 'admin',
 });
 ```
 

--- a/examples/mcp/tool-filter-example.ts
+++ b/examples/mcp/tool-filter-example.ts
@@ -2,7 +2,7 @@ import {
   Agent,
   run,
   MCPServerStdio,
-  createStaticToolFilter,
+  createMCPToolStaticFilter,
   withTrace,
 } from '@openai/agents';
 import * as path from 'node:path';
@@ -12,7 +12,7 @@ async function main() {
   const mcpServer = new MCPServerStdio({
     name: 'Filesystem Server with filter',
     fullCommand: `npx -y @modelcontextprotocol/server-filesystem ${samplesDir}`,
-    toolFilter: createStaticToolFilter({
+    toolFilter: createMCPToolStaticFilter({
       allowed: ['read_file', 'list_directory'],
       blocked: ['write_file'],
     }),

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -74,10 +74,10 @@ export {
   MCPServerStreamableHttp,
 } from './mcp';
 export {
-  ToolFilterCallable,
-  ToolFilterContext,
-  ToolFilterStatic,
-  createStaticToolFilter,
+  MCPToolFilterCallable,
+  MCPToolFilterContext,
+  MCPToolFilterStatic,
+  createMCPToolStaticFilter,
 } from './mcpUtil';
 export {
   Model,

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -14,7 +14,7 @@ import {
   JsonObjectSchemaStrict,
   UnknownContext,
 } from './types';
-import type { ToolFilterCallable, ToolFilterStatic } from './mcpUtil';
+import type { MCPToolFilterCallable, MCPToolFilterStatic } from './mcpUtil';
 import type { RunContext } from './runContext';
 import type { Agent } from './agent';
 
@@ -46,7 +46,7 @@ export interface MCPServer {
 export abstract class BaseMCPServerStdio implements MCPServer {
   public cacheToolsList: boolean;
   protected _cachedTools: any[] | undefined = undefined;
-  protected toolFilter?: ToolFilterCallable | ToolFilterStatic;
+  protected toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
 
   protected logger: Logger;
   constructor(options: MCPServerStdioOptions) {
@@ -83,7 +83,7 @@ export abstract class BaseMCPServerStdio implements MCPServer {
 export abstract class BaseMCPServerStreamableHttp implements MCPServer {
   public cacheToolsList: boolean;
   protected _cachedTools: any[] | undefined = undefined;
-  protected toolFilter?: ToolFilterCallable | ToolFilterStatic;
+  protected toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
 
   protected logger: Logger;
   constructor(options: MCPServerStreamableHttpOptions) {
@@ -386,7 +386,7 @@ export interface BaseMCPServerStdioOptions {
   encoding?: string;
   encodingErrorHandler?: 'strict' | 'ignore' | 'replace';
   logger?: Logger;
-  toolFilter?: ToolFilterCallable | ToolFilterStatic;
+  toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
 }
 export interface DefaultMCPServerStdioOptions
   extends BaseMCPServerStdioOptions {
@@ -407,7 +407,7 @@ export interface MCPServerStreamableHttpOptions {
   clientSessionTimeoutSeconds?: number;
   name?: string;
   logger?: Logger;
-  toolFilter?: ToolFilterCallable | ToolFilterStatic;
+  toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
 
   // ----------------------------------------------------
   // OAuth

--- a/packages/agents-core/src/mcpUtil.ts
+++ b/packages/agents-core/src/mcpUtil.ts
@@ -4,7 +4,7 @@ import type { MCPTool } from './mcp';
 import type { UnknownContext } from './types';
 
 /** Context information available to tool filter functions. */
-export interface ToolFilterContext<TContext = UnknownContext> {
+export interface MCPToolFilterContext<TContext = UnknownContext> {
   /** The current run context. */
   runContext: RunContext<TContext>;
   /** The agent requesting the tools. */
@@ -14,13 +14,13 @@ export interface ToolFilterContext<TContext = UnknownContext> {
 }
 
 /** A function that determines whether a tool should be available. */
-export type ToolFilterCallable<TContext = UnknownContext> = (
-  context: ToolFilterContext<TContext>,
+export type MCPToolFilterCallable<TContext = UnknownContext> = (
+  context: MCPToolFilterContext<TContext>,
   tool: MCPTool,
 ) => boolean | Promise<boolean>;
 
 /** Static tool filter configuration using allow and block lists. */
-export interface ToolFilterStatic {
+export interface MCPToolFilterStatic {
   /** Optional list of tool names to allow. */
   allowedToolNames?: string[];
   /** Optional list of tool names to block. */
@@ -28,14 +28,14 @@ export interface ToolFilterStatic {
 }
 
 /** Convenience helper to create a static tool filter. */
-export function createStaticToolFilter(options?: {
+export function createMCPToolStaticFilter(options?: {
   allowed?: string[];
   blocked?: string[];
-}): ToolFilterStatic | undefined {
+}): MCPToolFilterStatic | undefined {
   if (!options?.allowed && !options?.blocked) {
     return undefined;
   }
-  const filter: ToolFilterStatic = {};
+  const filter: MCPToolFilterStatic = {};
   if (options?.allowed) {
     filter.allowedToolNames = options.allowed;
   }

--- a/packages/agents-core/test/mcpToolFilter.test.ts
+++ b/packages/agents-core/test/mcpToolFilter.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { withTrace } from '../src/tracing';
 import { NodeMCPServerStdio } from '../src/shims/mcp-server/node';
-import { createStaticToolFilter } from '../src/mcpUtil';
+import { createMCPToolStaticFilter } from '../src/mcpUtil';
 import { Agent } from '../src/agent';
 import { RunContext } from '../src/runContext';
 
@@ -49,7 +49,7 @@ describe('MCP tool filtering', () => {
       const server = new StubServer(
         's',
         tools,
-        createStaticToolFilter({ allowed: ['a'], blocked: ['b'] }),
+        createMCPToolStaticFilter({ allowed: ['a'], blocked: ['b'] }),
       );
       const agent = new Agent({
         name: 'agent',
@@ -144,7 +144,7 @@ describe('MCP tool filtering', () => {
       const serverA = new StubServer(
         'A',
         toolsA,
-        createStaticToolFilter({ allowed: ['a1'] }),
+        createMCPToolStaticFilter({ allowed: ['a1'] }),
       );
       const serverB = new StubServer('B', toolsB);
       const agent = new Agent({
@@ -180,7 +180,7 @@ describe('MCP tool filtering', () => {
       const server = new StubServer(
         'cache',
         tools,
-        createStaticToolFilter({ allowed: ['x'] }),
+        createMCPToolStaticFilter({ allowed: ['x'] }),
       );
       const agent = new Agent({
         name: 'agent',
@@ -193,7 +193,9 @@ describe('MCP tool filtering', () => {
       const runContext = new RunContext();
       let result = await server.listTools(runContext, agent);
       expect(result.map((t) => t.name)).toEqual(['x']);
-      (server as any).toolFilter = createStaticToolFilter({ allowed: ['y'] });
+      (server as any).toolFilter = createMCPToolStaticFilter({
+        allowed: ['y'],
+      });
       result = await server.listTools(runContext, agent);
       expect(result.map((t) => t.name)).toEqual(['x']);
     });


### PR DESCRIPTION
## Summary
- rename `ToolFilter` utilities to use `MCP` prefix
- update docs, examples and tests

## Testing
- `pnpm build`
- `CI=1 pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6876972aba44832dbbd4035671b7120d