### PR TITLE
Add output type generics to RunResult and RunState

### DIFF
--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -442,7 +442,7 @@ export class Agent<
      * from the agent will be used.
      */
     customOutputExtractor?: (
-      output: RunResult<TContext, Agent<TContext, any>>,
+      output: RunResult<TContext, Agent<TContext, any>, any>,
     ) => string | Promise<string>;
   }): FunctionTool {
     const { toolName, toolDescription, customOutputExtractor } = options;

--- a/packages/agents-core/src/errors.ts
+++ b/packages/agents-core/src/errors.ts
@@ -11,9 +11,9 @@ import { TextOutput } from './types';
  * Base class for all errors thrown by the library.
  */
 export abstract class AgentsError extends Error {
-  state?: RunState<any, Agent<any, any>>;
+  state?: RunState<any, Agent<any, any>, any>;
 
-  constructor(message: string, state?: RunState<any, Agent<any, any>>) {
+  constructor(message: string, state?: RunState<any, Agent<any, any>, any>) {
     super(message);
     this.state = state;
   }
@@ -48,7 +48,7 @@ export class GuardrailExecutionError extends AgentsError {
   constructor(
     message: string,
     error: Error,
-    state?: RunState<any, Agent<any, any>>,
+    state?: RunState<any, Agent<any, any>, any>,
   ) {
     super(message, state);
     this.error = error;
@@ -63,7 +63,7 @@ export class ToolCallError extends AgentsError {
   constructor(
     message: string,
     error: Error,
-    state?: RunState<any, Agent<any, any>>,
+    state?: RunState<any, Agent<any, any>, any>,
   ) {
     super(message, state);
     this.error = error;
@@ -78,7 +78,7 @@ export class InputGuardrailTripwireTriggered extends AgentsError {
   constructor(
     message: string,
     result: InputGuardrailResult,
-    state?: RunState<any, any>,
+    state?: RunState<any, any, any>,
   ) {
     super(message, state);
     this.result = result;
@@ -96,7 +96,7 @@ export class OutputGuardrailTripwireTriggered<
   constructor(
     message: string,
     result: OutputGuardrailResult<TMeta, TOutputType>,
-    state?: RunState<any, any>,
+    state?: RunState<any, any, any>,
   ) {
     super(message, state);
     this.result = result;

--- a/packages/agents-core/src/runImplementation.ts
+++ b/packages/agents-core/src/runImplementation.ts
@@ -300,7 +300,7 @@ export async function executeInterruptedToolsAndSideEffects<TContext>(
   newResponse: ModelResponse,
   processedResponse: ProcessedResponse,
   runner: Runner,
-  state: RunState<TContext, Agent<TContext, any>>,
+  state: RunState<TContext, Agent<TContext, any>, any>,
 ): Promise<SingleStepResult> {
   // call_ids for function tools
   const functionCallIds = originalPreStepItems
@@ -430,7 +430,7 @@ export async function executeToolsAndSideEffects<TContext>(
   newResponse: ModelResponse,
   processedResponse: ProcessedResponse<TContext>,
   runner: Runner,
-  state: RunState<TContext, Agent<TContext, any>>,
+  state: RunState<TContext, Agent<TContext, any>, any>,
 ): Promise<SingleStepResult> {
   const preStepItems = originalPreStepItems;
   let newItems = processedResponse.newItems;
@@ -658,7 +658,7 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
   agent: Agent<any, any>,
   toolRuns: ToolRunFunction<unknown>[],
   runner: Runner,
-  state: RunState<TContext, Agent<any, any>>,
+  state: RunState<TContext, Agent<any, any>, any>,
 ): Promise<FunctionToolResult[]> {
   async function runSingleTool(toolRun: ToolRunFunction<unknown>) {
     let parsedArgs: any = toolRun.toolCall.arguments;
@@ -1064,7 +1064,7 @@ export async function checkForFinalOutputFromTools<
 >(
   agent: Agent<TContext, TOutput>,
   toolResults: FunctionToolResult[],
-  state: RunState<TContext, Agent<TContext, TOutput>>,
+  state: RunState<TContext, Agent<TContext, TOutput>, TOutput>,
 ): Promise<ToolsToFinalOutputResult> {
   if (toolResults.length === 0) {
     return NOT_FINAL_OUTPUT;
@@ -1123,7 +1123,7 @@ export async function checkForFinalOutputFromTools<
 }
 
 export function addStepToRunResult(
-  result: StreamedRunResult<any, any>,
+  result: StreamedRunResult<any, any, any>,
   step: SingleStepResult,
 ): void {
   for (const item of step.newStepItems) {

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -1,5 +1,5 @@
 import { z } from '@openai/zod/v3';
-import { Agent } from './agent';
+import { Agent, AgentOutputType } from './agent';
 import {
   RunMessageOutputItem,
   RunItem,
@@ -241,7 +241,11 @@ export const SerializedRunState = z.object({
  * Manipulation of the state directly can lead to unexpected behavior and should be avoided.
  * Instead, use the `approve` and `reject` methods to interact with the state.
  */
-export class RunState<TContext, TAgent extends Agent<any, any>> {
+export class RunState<
+  TContext,
+  TAgent extends Agent<TContext, TAgentOutputType>,
+  TAgentOutputType extends AgentOutputType,
+> {
   /**
    * Current turn number in the conversation.
    */
@@ -450,10 +454,11 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
    * This method is used to deserialize a run state from a string that was serialized using the
    * `toString` method.
    */
-  static async fromString<TContext, TAgent extends Agent<any, any>>(
-    initialAgent: TAgent,
-    str: string,
-  ) {
+  static async fromString<
+    TContext,
+    TAgentOutputType extends AgentOutputType,
+    TAgent extends Agent<TContext, TAgentOutputType>,
+  >(initialAgent: TAgent, str: string) {
     const [parsingError, jsonResult] = await safeExecute(() => JSON.parse(str));
     if (parsingError) {
       throw new UserError(
@@ -491,7 +496,7 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
       throw new UserError(`Agent ${stateJson.currentAgent.name} not found`);
     }
 
-    const state = new RunState<TContext, TAgent>(
+    const state = new RunState<TContext, TAgent, TAgentOutputType>(
       context,
       '',
       currentAgent as TAgent,

--- a/packages/agents-core/test/result.test.ts
+++ b/packages/agents-core/test/result.test.ts
@@ -8,7 +8,7 @@ import logger from '../src/logger';
 
 const agent = new Agent({ name: 'A' });
 
-function createState(): RunState<unknown, Agent<any, any>> {
+function createState(): RunState<unknown, Agent<any, any>, any> {
   return new RunState(new RunContext(), '', agent, 1);
 }
 

--- a/packages/agents-core/test/runImplementation.test.ts
+++ b/packages/agents-core/test/runImplementation.test.ts
@@ -143,7 +143,7 @@ describe('getToolCallOutputItem', () => {
 });
 
 describe('checkForFinalOutputFromTools', () => {
-  const state: RunState<any, any> = {} as any;
+  const state: RunState<any, any, any> = {} as any;
 
   // create a fake FunctionTool and corresponding result object that matches
   const weatherTool = tool({
@@ -471,7 +471,7 @@ describe('executeFunctionToolCalls', () => {
     });
   }
 
-  let state: RunState<any, any>;
+  let state: RunState<any, any, any>;
   let runner: Runner;
 
   beforeEach(() => {
@@ -741,7 +741,7 @@ describe('executeHandoffCalls', () => {
 });
 
 describe('checkForFinalOutputFromTools interruptions and errors', () => {
-  const state: RunState<any, any> = {} as any;
+  const state: RunState<any, any, any> = {} as any;
 
   it('returns interruptions when approval items present', async () => {
     const agent = new Agent({ name: 'A', toolUseBehavior: 'run_llm_again' });
@@ -870,7 +870,7 @@ describe('hasToolsOrApprovalsToRun method', () => {
 
 describe('executeToolsAndSideEffects', () => {
   let runner: Runner;
-  let state: RunState<any, any>;
+  let state: RunState<any, any, any>;
 
   beforeEach(() => {
     runner = new Runner({ tracingDisabled: true });


### PR DESCRIPTION
## Summary
- carry agent output type in `RunResult` and `RunState`
- update internal implementations and tests for new generics

## Testing
- `pnpm -r -F @openai/agents-core build`
- `pnpm test`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688c630033f0832d84f03183b05353b5