### PR TITLE
docs: add websocket stub to twilio example

### DIFF
--- a/examples/docs/extensions/twilio-basic.ts
+++ b/examples/docs/extensions/twilio-basic.ts
@@ -1,6 +1,9 @@
 import { TwilioRealtimeTransportLayer } from '@openai/agents-extensions';
 import { RealtimeAgent, RealtimeSession } from '@openai/agents/realtime';
 
+// Mock WebSocket connection for demonstration purposes.
+const websocketConnection = {} as WebSocket;
+
 const agent = new RealtimeAgent({
   name: 'My Agent',
 });
@@ -8,7 +11,6 @@ const agent = new RealtimeAgent({
 // Create a new transport mechanism that will bridge the connection between Twilio and
 // the OpenAI Realtime API.
 const twilioTransport = new TwilioRealtimeTransportLayer({
-  // @ts-expect-error - this is not defined
   twilioWebSocket: websocketConnection,
 });
 


### PR DESCRIPTION
## Summary
- stub WebSocket connection in Twilio transport example to avoid undefined reference

## Testing
- `pnpm lint examples/docs/extensions/twilio-basic.ts`
- `pnpm -F docs build-check` *(fails: voice-agents/defineTool.ts(8,9): error TS2322: Type '({ city }: { city: any; }) => Promise<string>' is not assignable to type 'ToolExecuteFunction<...>')*


------
https://chatgpt.com/codex/tasks/task_e_688dbd29d2d0832dba65dad0c0c1bee2