### PR TITLE
docs: add Cloudflare Worker typings

### DIFF
--- a/examples/docs/package.json
+++ b/examples/docs/package.json
@@ -15,6 +15,7 @@
     "build-check": "tsc --noEmit"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250802.0",
     "typedoc-plugin-zod": "^1.4.1"
   }
 }

--- a/examples/docs/tracing/cloudflareWorkers.ts
+++ b/examples/docs/tracing/cloudflareWorkers.ts
@@ -1,8 +1,8 @@
 import { getGlobalTraceProvider } from '@openai/agents';
+import type { Context, Env } from '@cloudflare/workers-types';
 
 export default {
-  // @ts-expect-error - Cloudflare Workers types are not typed
-  async fetch(request, env, ctx): Promise<Response> {
+  async fetch(request: Request, env: Env, ctx: Context): Promise<Response> {
     try {
       // your agent code here
       return new Response(`success`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
         specifier: 3.25.40 - 3.25.67
         version: 3.25.62
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20250802.0
+        version: 4.20250802.0
       typedoc-plugin-zod:
         specifier: ^1.4.1
         version: 1.4.1(typedoc@0.28.5(typescript@5.8.3))
@@ -702,6 +705,9 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@cloudflare/workers-types@4.20250802.0':
+    resolution: {integrity: sha512-zWjDMBxPf4kv4air928Qpo1fmIacMKbztO4R3+fdrB2stn0425zJrqhRGye27e/v9cA1Jum8IHl7Q/P2ZIT2QA==}
 
   '@ctrl/tinycolor@4.1.0':
     resolution: {integrity: sha512-WyOx8cJQ+FQus4Mm4uPIZA64gbk3Wxh0so5Lcii0aJifqwoVOlfFtorjLE0Hen4OYyHZMXDWqMmaQemBhgxFRQ==}
@@ -6544,6 +6550,8 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.1
       prettier: 2.8.8
+
+  '@cloudflare/workers-types@4.20250802.0': {}
 
   '@ctrl/tinycolor@4.1.0': {}
 


### PR DESCRIPTION
## Summary
- annotate Cloudflare Worker request, env, and context parameters with official types
- include Cloudflare Worker type definitions in docs example package

## Testing
- `pnpm lint examples/docs/tracing/cloudflareWorkers.ts`
- `pnpm -F docs build-check` *(fails: examples/docs build-check: `tsc --noEmit`)*

------
https://chatgpt.com/codex/tasks/task_e_688dbd300494832d9f1c62534dde3ee8