### PR TITLE
fix(agents-core): relax agent run generics

### DIFF
--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -129,7 +129,7 @@ export interface AgentConfiguration<
     | string
     | ((
         runContext: RunContext<TContext>,
-        agent: Agent<TContext, TOutput>,
+        agent: Agent<TContext, any>,
       ) => Promise<string> | string);
 
   /**
@@ -143,7 +143,7 @@ export interface AgentConfiguration<
     | Prompt
     | ((
         runContext: RunContext<TContext>,
-        agent: Agent<TContext, TOutput>,
+        agent: Agent<TContext, any>,
       ) => Promise<Prompt> | Prompt);
 
   /**
@@ -317,13 +317,13 @@ export class Agent<
     | string
     | ((
         runContext: RunContext<TContext>,
-        agent: Agent<TContext, TOutput>,
+        agent: Agent<TContext, any>,
       ) => Promise<string> | string);
   prompt?:
     | Prompt
     | ((
         runContext: RunContext<TContext>,
-        agent: Agent<TContext, TOutput>,
+        agent: Agent<TContext, any>,
       ) => Promise<Prompt> | Prompt);
   handoffDescription: string;
   handoffs: (Agent<any, TOutput> | Handoff<any, TOutput>)[];

--- a/packages/agents-core/src/result.ts
+++ b/packages/agents-core/src/result.ts
@@ -1,4 +1,4 @@
-import { Agent, AgentOutputType } from './agent';
+import { Agent } from './agent';
 import { Handoff } from './handoff';
 import {
   ResolvedAgentOutput,
@@ -26,7 +26,8 @@ import { StreamEventTextStream } from './types/protocol';
  * Data returned by the run() method of an agent.
  */
 export interface RunResultData<
-  TAgent extends Agent<any, any>,
+  TContext,
+  TAgent extends Agent<TContext, any>,
   THandoffs extends (Agent<any, any> | Handoff<any>)[] = any[],
 > {
   /**
@@ -81,11 +82,11 @@ export interface RunResultData<
   /**
    * The state of the run.
    */
-  state: RunState<any, TAgent>;
+  state: RunState<TContext, TAgent>;
 }
 
 class RunResultBase<TContext, TAgent extends Agent<TContext, any>>
-  implements RunResultData<TAgent>
+  implements RunResultData<TContext, TAgent>
 {
   readonly state: RunState<TContext, TAgent>;
 
@@ -201,7 +202,7 @@ class RunResultBase<TContext, TAgent extends Agent<TContext, any>>
  */
 export class RunResult<
   TContext,
-  TAgent extends Agent<TContext, AgentOutputType>,
+  TAgent extends Agent<TContext, any>,
 > extends RunResultBase<TContext, TAgent> {
   constructor(state: RunState<TContext, TAgent>) {
     super(state);
@@ -211,10 +212,7 @@ export class RunResult<
 /**
  * The result of an agent run in streaming mode.
  */
-export class StreamedRunResult<
-    TContext,
-    TAgent extends Agent<TContext, AgentOutputType>,
-  >
+export class StreamedRunResult<TContext, TAgent extends Agent<TContext, any>>
   extends RunResultBase<TContext, TAgent>
   implements AsyncIterable<RunStreamEvent>
 {

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -230,7 +230,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
    */
   async #runIndividualNonStream<
     TContext,
-    TAgent extends Agent<TContext, AgentOutputType>,
+    TAgent extends Agent<TContext, any>,
     _THandoffs extends (Agent<any, any> | Handoff<any>)[] = any[],
   >(
     startingAgent: TAgent,
@@ -486,10 +486,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     });
   }
 
-  async #runInputGuardrails<
-    TContext,
-    TAgent extends Agent<TContext, AgentOutputType>,
-  >(state: RunState<TContext, TAgent>) {
+  async #runInputGuardrails<TContext, TAgent extends Agent<TContext, any>>(
+    state: RunState<TContext, TAgent>,
+  ) {
     const guardrails = this.inputGuardrailDefs.concat(
       state._currentAgent.inputGuardrails.map(defineInputGuardrail),
     );
@@ -543,17 +542,19 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     }
   }
 
-  async #runOutputGuardrails<
-    TContext,
-    TOutput extends AgentOutputType,
-    TAgent extends Agent<TContext, TOutput>,
-  >(state: RunState<TContext, TAgent>, output: string) {
+  async #runOutputGuardrails<TContext, TAgent extends Agent<TContext, any>>(
+    state: RunState<TContext, TAgent>,
+    output: string,
+  ) {
     const guardrails = this.outputGuardrailDefs.concat(
       state._currentAgent.outputGuardrails.map(defineOutputGuardrail),
     );
     if (guardrails.length > 0) {
       const agentOutput = state._currentAgent.processFinalOutput(output);
-      const guardrailArgs: OutputGuardrailFunctionArgs<unknown, TOutput> = {
+      const guardrailArgs: OutputGuardrailFunctionArgs<
+        unknown,
+        TAgent['outputType']
+      > = {
         agent: state._currentAgent,
         agentOutput,
         context: state._context,
@@ -604,10 +605,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
   /**
    * @internal
    */
-  async #runStreamLoop<
-    TContext,
-    TAgent extends Agent<TContext, AgentOutputType>,
-  >(
+  async #runStreamLoop<TContext, TAgent extends Agent<TContext, any>>(
     result: StreamedRunResult<TContext, TAgent>,
     options: StreamRunOptions<TContext>,
   ): Promise<void> {
@@ -858,10 +856,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
   /**
    * @internal
    */
-  async #runIndividualStream<
-    TContext,
-    TAgent extends Agent<TContext, AgentOutputType>,
-  >(
+  async #runIndividualStream<TContext, TAgent extends Agent<TContext, any>>(
     agent: TAgent,
     input: string | AgentInputItem[] | RunState<TContext, TAgent>,
     options?: StreamRunOptions<TContext>,

--- a/packages/agents-core/src/runImplementation.ts
+++ b/packages/agents-core/src/runImplementation.ts
@@ -655,10 +655,10 @@ export function getToolCallOutputItem(
  * @internal
  */
 export async function executeFunctionToolCalls<TContext = UnknownContext>(
-  agent: Agent<any, any>,
+  agent: Agent<TContext, any>,
   toolRuns: ToolRunFunction<unknown>[],
   runner: Runner,
-  state: RunState<TContext, Agent<any, any>>,
+  state: RunState<TContext, Agent<TContext, any>>,
 ): Promise<FunctionToolResult[]> {
   async function runSingleTool(toolRun: ToolRunFunction<unknown>) {
     let parsedArgs: any = toolRun.toolCall.arguments;

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -241,7 +241,7 @@ export const SerializedRunState = z.object({
  * Manipulation of the state directly can lead to unexpected behavior and should be avoided.
  * Instead, use the `approve` and `reject` methods to interact with the state.
  */
-export class RunState<TContext, TAgent extends Agent<any, any>> {
+export class RunState<TContext, TAgent extends Agent<TContext, any>> {
   /**
    * Current turn number in the conversation.
    */
@@ -450,7 +450,7 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
    * This method is used to deserialize a run state from a string that was serialized using the
    * `toString` method.
    */
-  static async fromString<TContext, TAgent extends Agent<any, any>>(
+  static async fromString<TContext, TAgent extends Agent<TContext, any>>(
     initialAgent: TAgent,
     str: string,
   ) {


### PR DESCRIPTION
## Summary
- allow agent callback signatures to accept any output type
- loosen runner helper generics and propagate agent context
- propagate agent context through run state and result types

## Testing
- `pnpm -F agents-core build`
- `pnpm build`
- `CI=1 pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688e6ed27454832d90169f99ad6ad290