### PR TITLE
build: add cjs build output and shim guards

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ import { globalIgnores } from 'eslint/config';
 export default tseslint.config(
   globalIgnores([
     '**/dist/**',
+    '**/dist-cjs/**',
     '**/node_modules/**',
     '**/docs/.astro/**',
     'examples/realtime-next/**',

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "clean": "tsc-multi --clean",
     "prebuild": "pnpm -F @openai/* -r prebuild",
-    "build": "tsc-multi",
+    "build:esm": "tsc-multi",
+    "build:cjs": "tsc-multi --config tsc-multi.cjs.json",
+    "build": "npm run build:esm && npm run build:cjs",
     "postbuild": "pnpm -r -F @openai/* bundle",
     "packages:dev": "tsc-multi --watch",
     "docs:dev": "pnpm -F docs dev",

--- a/packages/agents-core/package.json
+++ b/packages/agents-core/package.json
@@ -5,76 +5,51 @@
   "version": "0.0.14",
   "description": "The OpenAI Agents SDK is a lightweight yet powerful framework for building multi-agent workflows.",
   "author": "OpenAI <support@openai.com>",
-  "main": "dist/index.js",
+  "main": "./dist-cjs/index.cjs",
+  "module": "./dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "prebuild": "tsx ../../scripts/embedMeta.ts",
     "build": "tsc",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
     "build-check": "tsc --noEmit -p ./tsconfig.test.json"
   },
   "exports": {
     ".": {
-      "require": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.mjs"
+      "import": "./dist/index.js",
+      "require": "./dist-cjs/index.cjs"
     },
     "./model": {
-      "require": {
-        "types": "./dist/model.d.ts",
-        "default": "./dist/model.js"
-      },
-      "types": "./dist/model.d.ts",
-      "default": "./dist/model.mjs"
+      "import": "./dist/model.js",
+      "require": "./dist-cjs/model.cjs"
     },
     "./utils": {
-      "require": {
-        "types": "./dist/utils/index.d.ts",
-        "default": "./dist/utils/index.js"
-      },
-      "types": "./dist/utils/index.d.ts",
-      "default": "./dist/utils/index.mjs"
+      "import": "./dist/utils/index.js",
+      "require": "./dist-cjs/utils/index.cjs"
     },
     "./extensions": {
-      "require": {
-        "types": "./dist/extensions/index.d.ts",
-        "default": "./dist/extensions/index.js"
-      },
-      "types": "./dist/extensions/index.d.ts",
-      "default": "./dist/extensions/index.mjs"
+      "import": "./dist/extensions/index.js",
+      "require": "./dist-cjs/extensions/index.cjs"
     },
     "./types": {
-      "require": {
-        "types": "./dist/types/index.d.ts",
-        "default": "./dist/types/index.js"
-      },
-      "types": "./dist/types/index.d.ts",
-      "default": "./dist/types/index.mjs"
+      "import": "./dist/types/index.js",
+      "require": "./dist-cjs/types/index.cjs"
     },
     "./_shims": {
+      "import": "./dist/shims/shims-node.mjs",
+      "require": "./dist-cjs/shims/shims-node.cjs",
       "workerd": {
-        "require": "./dist/shims/shims-workerd.js",
-        "types": "./dist/shims/shims-workerd.d.ts",
-        "default": "./dist/shims/shims-workerd.mjs"
+        "import": "./dist/shims/shims-workerd.mjs",
+        "require": "./dist-cjs/shims/shims-workerd.cjs"
       },
       "browser": {
-        "require": "./dist/shims/shims-browser.js",
-        "types": "./dist/shims/shims-browser.d.ts",
-        "default": "./dist/shims/shims-browser.mjs"
+        "import": "./dist/shims/shims-browser.mjs",
+        "require": "./dist-cjs/shims/shims-browser.cjs"
       },
       "node": {
-        "require": "./dist/shims/shims-node.js",
-        "types": "./dist/shims/shims-node.d.ts",
-        "default": "./dist/shims/shims-node.mjs"
-      },
-      "require": {
-        "types": "./dist/shims/shims-node.d.ts",
-        "default": "./dist/shims/shims-node.js"
-      },
-      "types": "./dist/shims/shims-node.d.ts",
-      "default": "./dist/shims/shims-node.mjs"
+        "import": "./dist/shims/shims-node.mjs",
+        "require": "./dist-cjs/shims/shims-node.cjs"
+      }
     }
   },
   "keywords": [
@@ -124,6 +99,7 @@
     "zod": "3.25.40 - 3.25.67"
   },
   "files": [
-    "dist"
+    "dist",
+    "dist-cjs/**"
   ]
 }

--- a/packages/agents-core/src/shims/shims-node.ts
+++ b/packages/agents-core/src/shims/shims-node.ts
@@ -14,11 +14,13 @@ declare global {
 // circular dependency resolution issues caused by other exports in '@openai/agents-core/_shims'
 export function loadEnv(): Record<string, string | undefined> {
   if (typeof process === 'undefined' || typeof process.env === 'undefined') {
-    if (
-      typeof import.meta === 'object' &&
-      typeof import.meta.env === 'object'
-    ) {
-      return import.meta.env as unknown as Record<string, string | undefined>;
+    try {
+      const m = (0, eval)('import.meta');
+      if (typeof m === 'object' && typeof m.env === 'object') {
+        return m.env as unknown as Record<string, string | undefined>;
+      }
+    } catch {
+      /* CJS. */
     }
     return {};
   }

--- a/packages/agents-core/src/shims/shims-workerd.ts
+++ b/packages/agents-core/src/shims/shims-workerd.ts
@@ -15,11 +15,13 @@ declare global {
 // circular dependency resolution issues caused by other exports in '@openai/agents-core/_shims'
 export function loadEnv(): Record<string, string | undefined> {
   if (typeof process === 'undefined' || typeof process.env === 'undefined') {
-    if (
-      typeof import.meta === 'object' &&
-      typeof import.meta.env === 'object'
-    ) {
-      return import.meta.env as unknown as Record<string, string | undefined>;
+    try {
+      const m = (0, eval)('import.meta');
+      if (typeof m === 'object' && typeof m.env === 'object') {
+        return m.env as unknown as Record<string, string | undefined>;
+      }
+    } catch {
+      /* CJS. */
     }
     return {};
   }

--- a/packages/agents-core/tsconfig.cjs.json
+++ b/packages/agents-core/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./dist-cjs"
+  },
+  "exclude": ["dist/**", "dist-cjs/**", "test/**"]
+}

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -5,37 +5,27 @@
   "version": "0.0.14",
   "description": "The OpenAI Agents SDK is a lightweight yet powerful framework for building multi-agent workflows.",
   "author": "OpenAI <support@openai.com>",
-  "main": "dist/index.js",
+  "main": "./dist-cjs/index.cjs",
+  "module": "./dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "require": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.mjs"
+      "import": "./dist/index.js",
+      "require": "./dist-cjs/index.cjs"
     },
     "./realtime": {
-      "require": {
-        "types": "./dist/realtime/index.d.ts",
-        "default": "./dist/realtime/index.js"
-      },
-      "types": "./dist/realtime/index.d.ts",
-      "default": "./dist/realtime/index.mjs"
+      "import": "./dist/realtime/index.js",
+      "require": "./dist-cjs/realtime/index.cjs"
     },
     "./utils": {
-      "require": {
-        "types": "./dist/utils/index.d.ts",
-        "default": "./dist/utils/index.js"
-      },
-      "types": "./dist/utils/index.d.ts",
-      "default": "./dist/utils/index.mjs"
+      "import": "./dist/utils/index.js",
+      "require": "./dist-cjs/utils/index.cjs"
     }
   },
   "scripts": {
     "prebuild": "tsx ../../scripts/embedMeta.ts",
     "build": "tsc",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
     "build-check": "tsc --noEmit -p ./tsconfig.test.json"
   },
   "dependencies": {
@@ -56,7 +46,8 @@
     "@types/debug": "^4.1.12"
   },
   "files": [
-    "dist"
+    "dist",
+    "dist-cjs/**"
   ],
   "typesVersions": {
     "*": {

--- a/packages/agents/tsconfig.cjs.json
+++ b/packages/agents/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./dist-cjs"
+  },
+  "exclude": ["dist/**", "dist-cjs/**", "test/**"]
+}

--- a/tsc-multi.cjs.json
+++ b/tsc-multi.cjs.json
@@ -1,0 +1,9 @@
+{
+  "targets": [
+    { "extname": ".cjs", "module": "commonjs", "moduleResolution": "node" }
+  ],
+  "projects": [
+    "packages/agents-core/tsconfig.cjs.json",
+    "packages/agents/tsconfig.cjs.json"
+  ]
+}


### PR DESCRIPTION
## Summary
- add tsconfig.cjs.json for agents and agents-core packages
- dual-build ESM and CJS via new root build scripts
- protect import.meta usage in shims for CJS safety

## Testing
- `pnpm build`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68901c5d54c0832d9b69a43764fb999f