### PR TITLE
feat: add commonjs build for agents-openai

### DIFF
--- a/packages/agents-openai/package.json
+++ b/packages/agents-openai/package.json
@@ -5,16 +5,13 @@
   "version": "0.0.14",
   "description": "The OpenAI Agents SDK is a lightweight yet powerful framework for building multi-agent workflows.",
   "author": "OpenAI <support@openai.com>",
-  "main": "dist/index.js",
+  "main": "./dist-cjs/index.cjs",
+  "module": "./dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "require": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.mjs"
+      "import": "./dist/index.js",
+      "require": "./dist-cjs/index.cjs"
     }
   },
   "dependencies": {
@@ -26,6 +23,7 @@
   "scripts": {
     "prebuild": "tsx ../../scripts/embedMeta.ts",
     "build": "tsc",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
     "build-check": "tsc --noEmit -p ./tsconfig.test.json"
   },
   "keywords": [
@@ -40,6 +38,7 @@
     "@types/debug": "^4.1.12"
   },
   "files": [
-    "dist"
+    "dist",
+    "dist-cjs/**"
   ]
 }

--- a/packages/agents-openai/tsconfig.cjs.json
+++ b/packages/agents-openai/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./dist-cjs"
+  },
+  "exclude": ["dist/**", "dist-cjs/**", "test/**"]
+}

--- a/tsc-multi.cjs.json
+++ b/tsc-multi.cjs.json
@@ -4,6 +4,7 @@
   ],
   "projects": [
     "packages/agents-core/tsconfig.cjs.json",
-    "packages/agents/tsconfig.cjs.json"
+    "packages/agents/tsconfig.cjs.json",
+    "packages/agents-openai/tsconfig.cjs.json"
   ]
 }


### PR DESCRIPTION
## Summary
- add tsconfig for agents-openai CJS build
- expose CommonJS entry point and scripts in agents-openai package
- include agents-openai in tsc-multi CJS projects

## Testing
- `pnpm build`
- `pnpm -r build-check` *(fails: @openai/agents-realtime build-check: TypeScript errors)*
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689116d7cc8c832da78e1561ab3f4f30