### PR TITLE
fix: order types condition before import and require

### DIFF
--- a/packages/agents-core/package.json
+++ b/packages/agents-core/package.json
@@ -16,34 +16,34 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist-cjs/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist-cjs/index.cjs"
     },
     "./model": {
+      "types": "./dist/model.d.ts",
       "import": "./dist/model.js",
-      "require": "./dist-cjs/model.cjs",
-      "types": "./dist/model.d.ts"
+      "require": "./dist-cjs/model.cjs"
     },
     "./utils": {
+      "types": "./dist/utils/index.d.ts",
       "import": "./dist/utils/index.js",
-      "require": "./dist-cjs/utils/index.cjs",
-      "types": "./dist/utils/index.d.ts"
+      "require": "./dist-cjs/utils/index.cjs"
     },
     "./extensions": {
+      "types": "./dist/extensions/index.d.ts",
       "import": "./dist/extensions/index.js",
-      "require": "./dist-cjs/extensions/index.cjs",
-      "types": "./dist/extensions/index.d.ts"
+      "require": "./dist-cjs/extensions/index.cjs"
     },
     "./types": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/types/index.js",
-      "require": "./dist-cjs/types/index.cjs",
-      "types": "./dist/types/index.d.ts"
+      "require": "./dist-cjs/types/index.cjs"
     },
     "./_shims": {
+      "types": "./dist/shims/shims-node.d.ts",
       "import": "./dist/shims/shims-node.mjs",
-      "require": "./dist-cjs/shims/shims-node.cjs",
-      "types": "./dist/shims/shims-node.d.ts"
+      "require": "./dist-cjs/shims/shims-node.cjs"
     }
   },
   "keywords": [

--- a/packages/agents-extensions/package.json
+++ b/packages/agents-extensions/package.json
@@ -20,11 +20,11 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       },
-      "types": "./dist/index.d.ts",
       "default": "./dist/index.mjs"
     }
   },

--- a/packages/agents-realtime/package.json
+++ b/packages/agents-realtime/package.json
@@ -10,14 +10,14 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist-cjs/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist-cjs/index.cjs"
     },
     "./_shims": {
+      "types": "./dist/shims/shims-node.d.ts",
       "import": "./dist/shims/shims-node.mjs",
-      "require": "./dist-cjs/shims/shims-node.cjs",
-      "types": "./dist/shims/shims-node.d.ts"
+      "require": "./dist-cjs/shims/shims-node.cjs"
     }
   },
   "scripts": {

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -10,24 +10,24 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist-cjs/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist-cjs/index.cjs"
     },
     "./realtime": {
+      "types": "./dist/realtime/index.d.ts",
       "import": "./dist/realtime/index.js",
-      "require": "./dist-cjs/realtime/index.cjs",
-      "types": "./dist/realtime/index.d.ts"
+      "require": "./dist-cjs/realtime/index.cjs"
     },
     "./utils": {
+      "types": "./dist/utils/index.d.ts",
       "import": "./dist/utils/index.js",
-      "require": "./dist-cjs/utils/index.cjs",
-      "types": "./dist/utils/index.d.ts"
+      "require": "./dist-cjs/utils/index.cjs"
     },
     "./_shims": {
+      "types": "./dist/shims/shims-node.d.ts",
       "import": "./dist/shims/shims-node.mjs",
-      "require": "./dist-cjs/shims/shims-node.cjs",
-      "types": "./dist/shims/shims-node.d.ts"
+      "require": "./dist-cjs/shims/shims-node.cjs"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- order `types` condition before runtime conditions in package exports to silence Node warnings

## Testing
- `pnpm build`
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68915d5cfcb8832dba88e35704caaa24